### PR TITLE
Update link to my lecture material

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Please tunnel into the sub-folders for organizing material.
 - [Land ice velocity (golive) including bootstrapping xarray](https://github.com/robfatland/golive), reviewed by  Siyu Yang 
 - [Bio-Acoustic Transfer learning (@pshivraj)](https://github.com/pshivraj/batl), reviewed by Sarah Barnes, Derya Gumustel 
 - [Unidata Python Workshop material](https://github.com/Unidata/python-workshop) 
-- [@brian-rose's climate modeling lecture notes](https://github.com/brian-rose/ClimateModeling_courseware)
+- [@brian-rose's Climate Laboratory book](https://brian-rose.github.io/ClimateLaboratoryBook/)
 - [Dask tutorial running on Pangeo Binder: Dataframes, Delayed and Scikit-learn](https://github.com/jcrist/anacondacon-2019-tutorial), originaly developed by @mrocklin [here](https:/hub.com/mrocklin/pydata-nyc-2018-tutorial) 
 - [Univ MD Baltimore County big data atmospheric science (flipped classroom)](http://cybertraining.umbc.edu/docs/UMBC_CyberTraininging_2019.pdf)
 - [A lightly opinionated guide to reproducible data science](https://the-turing-way.com) 


### PR DESCRIPTION
Replace the link to the deprecated ClimateModeling_courseware repo with a link to The Climate Laboratory jupyterbook website.